### PR TITLE
Bugfix dipsfsh2 workflow

### DIFF
--- a/.github/workflows/vitalsigns-gh-pages.yml
+++ b/.github/workflows/vitalsigns-gh-pages.yml
@@ -44,7 +44,7 @@ jobs:
       - name: 🏃‍♂️ Run IG Publisher
         uses: docker://hl7fhir/ig-publisher-base:latest
         with:
-          args: java -jar publisher.jar publisher -ig ${{ env.IG }}/ig.ini -publish https://hl7norway.github.io/no-domain-vitalsigns/
+          args: java -jar publisher.jar publisher -ig ${{ env.IG }}/ig.ini
 
       # Publishes the HTML page to a seperate branch in order to host it using GitHub-Pages.
       # This will overwrite the currently published HTML page.

--- a/.github/workflows/vitalsigns-gh-pages.yml
+++ b/.github/workflows/vitalsigns-gh-pages.yml
@@ -1,10 +1,6 @@
 name: VitalSigns-gh-pages
 
 on:
-  push:
-    branches: [master]
-    paths:
-      - ig-template/**
   workflow_dispatch:
 
 env:

--- a/VitalSigns/ig.ini
+++ b/VitalSigns/ig.ini
@@ -1,3 +1,5 @@
 [IG]
 ig = fsh-generated/resources/ImplementationGuide-hl7.fhir.no.domain.vitalsigns.json
+//ig = input/ImplementationGuide-dips.fhir.r4.observations.ig.json
 template = https://github.com/HL7Norway/ig-template
+//template = https://github.com/HL7/ig-template-base

--- a/VitalSigns/sushi-config.yaml
+++ b/VitalSigns/sushi-config.yaml
@@ -2,12 +2,12 @@
 # │  The properties below are used to create the ImplementationGuide resource. For a list of       │
 # │  supported properties, see: https://fshschool.org/docs/sushi/configuration/                    │
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-canonical: http://dips.no
-name: DIPSVitalSigns
+canonical: http://hl7.no/fhir
+name: NoDomainVitalSigns
 fhirVersion: 4.0.1
 FSHOnly: false
 applyExtensionMetadataToRoot: false
-id: dips.fhir.r4.observations.ig
+id: hl7.fhir.no.domain.vitalsigns
 status: draft
 version: 0.0.1-alpha
 releaseLabel: ci-build
@@ -21,4 +21,4 @@ dependencies:
 # ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 menu:
   Home: index.html
-  Artifacts:
+  Artifacts: artifacts.html


### PR DESCRIPTION
* Update the workflow to generate documationtion for hl7 norway domain
* update workflow and configufration files to NOT publish, only generate updated documentation to github.io (remove -publish flag for publisher)

The workflow is running [successfully](https://github.com/HL7Norway/no-domain/actions/runs/2102129089) on the current fsh code and documentation.